### PR TITLE
Use rust 1.82 and bump build number.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,12 +1,12 @@
 rust_compiler:
   - rust
 rust_compiler_version:
-  - 1.76.0
+  - 1.82.0
 # use {{ compiler('rust-gnu') }} when requiring a build using the m2w64-toolchain
 rust_gnu_compiler:             # [win]
   - rust-gnu                   # [win]
 rust_gnu_compiler_version:     # [win]
-  - 1.76.0                     # [win]
+  - 1.82.0                     # [win]
 MACOSX_DEPLOYMENT_TARGET:   # [osx and x86_64]
   - "10.12"                 # [osx and x86_64]
 CONDA_BUILD_SYSROOT:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ build:
 
 requirements:
   build:
-    - python
     - maturin >=1.2.3,<2
     - {{ compiler('c') }}
     - {{ compiler('rust') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4757a82a50406a0b3a333aa0122019a331bd6f16e49fed67dca423f928b3fd4d
 
 build:
-  number: 0
+  number: 1
   skip: True # [s390x]
   script:
     - {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6207](https://anaconda.atlassian.net/browse/PKG-6207)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6207]: https://anaconda.atlassian.net/browse/PKG-6207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ