### PR TITLE
Update for Python 3.13, update dep pinning

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
   host:
-    - maturin 1.3.1
+    - maturin >=1.2.3,<2
     - pip
     - python
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4757a82a50406a0b3a333aa0122019a331bd6f16e49fed67dca423f928b3fd4d
 
 build:
-  number: 1
+  number: 2
   skip: True # [s390x]
   script:
     - {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv


### PR DESCRIPTION
ypy 0.6.2

**Destination channel:** defaults

### Links

- [PKG-7144](https://anaconda.atlassian.net/browse/PKG-7144) 
- [Upstream repository](https://github.com/y-crdt/ypy)

### Explanation of changes:
- update for Python 3.13
- update pinning on maturin

[PKG-7144]: https://anaconda.atlassian.net/browse/PKG-7144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ